### PR TITLE
Revert Bundler version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -275,4 +275,4 @@ RUBY VERSION
    ruby 2.6.0p0
 
 BUNDLED WITH
-   2.0.1
+   1.16.0


### PR DESCRIPTION
Heroku does not support Bundler 2 yet.

See https://devcenter.heroku.com/articles/bundler-version